### PR TITLE
add pagination for ListAppsCommand

### DIFF
--- a/publish-to-amplify/package-lock.json
+++ b/publish-to-amplify/package-lock.json
@@ -3895,9 +3895,9 @@
             "dev": true
         },
         "node_modules/async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
             "dependencies": {
                 "lodash": "^4.17.14"
             }
@@ -13794,9 +13794,9 @@
             "dev": true
         },
         "async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
             "requires": {
                 "lodash": "^4.17.14"
             }

--- a/publish-to-amplify/src/amplifyUtils.tsx
+++ b/publish-to-amplify/src/amplifyUtils.tsx
@@ -28,7 +28,7 @@ export const getExistingAmplifyAppId = async (
   /* eslint-disable no-await-in-loop */
   do {
     const listAppResponse = await client.send(new ListAppsCommand({nextToken}));
-    if (listAppResponse.apps) {
+    if (listAppResponse?.apps) {
       const existingApp = listAppResponse.apps.find(
         (app) => app.name === appName && app.appId
       );
@@ -36,7 +36,7 @@ export const getExistingAmplifyAppId = async (
         return existingApp.appId;
       }
     }
-    nextToken = listAppResponse.nextToken;
+    nextToken = listAppResponse?.nextToken;
   } while (nextToken);
   /* eslint-enable no-await-in-loop */
   return undefined;


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
Current publish to Amplify plugin didn't include pagination feature for ListAppsCommand API call which will mistakenly overwrite customer's Amplify application.

## What was the solution? (How)
Added the pagination by checking the `nextToken` argument is null or not.

### Revision 1
Added two tests for pagination after test code was merged.

## What is the impact of this change? (Focus on the customer experience)
Avoid app to be overwritten when it is not listed in the first page.
 
## Are you adding any new dependencies to the system?
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
