### PR TITLE
remove quote for format script to make it work in windows

### DIFF
--- a/sumerian-hosts/package.json
+++ b/sumerian-hosts/package.json
@@ -9,7 +9,7 @@
         "compile": "tsc -p .",
         "lint": "eslint . ",
         "lint-fix": "eslint . --fix",
-        "format": "prettier 'src/**/*.ts*' 'scripts/*.ts*' --write",
+        "format": "prettier src/**/*.ts* scripts/*.ts* --write",
         "build": "npm run format && npm run lint-fix && npm run compile && npm run copy-config",
         "watch": "tsc -p . --watch",
         "copy-config": "cp -R ./config ./build/",


### PR DESCRIPTION
**Description of changes:**
remove the quote in the `format` script in `package.json` to make it work in Windows.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
