### PR TITLE
add real-time printout of spawnsync

### DIFF
--- a/open-source-hosts-plugin/tools/retrieveHostAssets.js
+++ b/open-source-hosts-plugin/tools/retrieveHostAssets.js
@@ -10,9 +10,11 @@ const path = require('path');
 const process = require('process');
 
 // check whether git exists. If not, throw the error and ask customers to install it.
-const {stdout, stderr, error} = spawnSync('git', ['--version']);
+const {stdout, error} = spawnSync('git', ['--version']);
 if (error) {
-  console.error(`${stderr} Please check that of Git is installed`);
+  console.error(
+    `${error} Please check that Git is installed and set as the environment variable.`
+  );
   process.exit(1);
 }
 console.log(stdout.toString('utf8'));


### PR DESCRIPTION
## Description of changes:
Current `git clone` cmd in the postinstall script is not including output or error message. By adding `stdio`, we can get `stderr` and `stdout` printed out from the child process to parent process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
