### PR TITLE
Add plugin name and version number to user agent for Amplify plugin

### DIFF
--- a/.github/workflows/amplify-plugin-pull-request.yml
+++ b/.github/workflows/amplify-plugin-pull-request.yml
@@ -21,5 +21,10 @@ jobs:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm install
+      # Write the commit hash into the constants file, so we get the git hash in the built artifacts
+      # Believe it or not, the following perl statement works on ubuntu/windows/macos
+      - name: "Set version number"
+        run: |
+          perl -i -p -e "s/PLUGIN_VERSION = .*/PLUGIN_VERSION = '${{ github.sha }}';/" ${{ github.workspace }}/aws-amplify-publisher-plugin/src/constants.tsx
       - run: npm run release
       # TODO: Perform CodeQL Analysis here

--- a/aws-amplify-publisher-plugin/src/amplifyPublishDialog.tsx
+++ b/aws-amplify-publisher-plugin/src/amplifyPublishDialog.tsx
@@ -10,7 +10,9 @@ import {Editor} from 'babylonjs-editor';
 
 import {AmplifyClient} from '@aws-sdk/client-amplify';
 
-import {Status} from './constants';
+import {Status, PLUGIN_VERSION} from './constants';
+
+
 
 import {
   getAmplifyPublishingPreferences,
@@ -114,7 +116,8 @@ export class AmplifyPublishDialog extends React.Component<
       domainAddress: '',
       error: '',
     };
-    this.client = new AmplifyClient({customUserAgent: 'babylonEditorPlugin'});
+
+    this.client = new AmplifyClient({customUserAgent: `AWSToolsForBabylonJS-${PLUGIN_VERSION}`});
   }
 
   /**

--- a/aws-amplify-publisher-plugin/src/constants.tsx
+++ b/aws-amplify-publisher-plugin/src/constants.tsx
@@ -11,3 +11,6 @@ export enum Status {
   Success = 'success',
   Failure = 'failure',
 }
+
+// Our Github Actions will replace this with a commit SHA at release time
+export const PLUGIN_VERSION = "development";


### PR DESCRIPTION
By default, the v3 SDK uses node libraries in electron/the editor, so we can't introspect the network traffic in the dev tools.

You can use something like the following to use the Fetch handler, so you can do so. I did this and noticed the useragent was set as expected
(Although other parts of the plugin don't work this way, so we can't leave it like this)

this.client = new AmplifyClient({customUserAgent: `AWSToolsForBabylonJS-${PLUGIN_VERSION}`, requestHandler: new FetchHttpHandler()});

I've also pushed this to my fork to test the github action, which writes the current git commit to the constants file. This let's us track a specific version.

When we setup the release process, we should change this to the version number, but wanted to use the commit hash for now as the workflow is the same

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
