### PR TITLE
Add Version number constant to Host script, and add it to the UserAgent

### DIFF
--- a/.github/workflows/host-plugin-pull-request.yml
+++ b/.github/workflows/host-plugin-pull-request.yml
@@ -36,6 +36,11 @@ jobs:
         working-directory: "./open-source-hosts-plugin"
       # END HOSTS SETUP
 
+      # Write the commit hash into the script file, so we get the git hash in the built artifacts
+      # Believe it or not, the following perl statement works on ubuntu/windows/macos
+      - name: "Set version number"
+        run: |
+          perl -i -p -e "s/PLUGIN_VERSION = .*/PLUGIN_VERSION = '${{ github.sha }}';/" ${{ github.workspace }}/open-source-hosts-plugin/scripts/sumerianhost.ts
       - run: npm install
         working-directory: "./open-source-hosts-plugin"
       - run: npm run release

--- a/open-source-hosts-plugin/scripts/sumerianhost.ts
+++ b/open-source-hosts-plugin/scripts/sumerianhost.ts
@@ -25,6 +25,11 @@ type SumerianHostVoiceConfiguration = {
   language: string;
 };
 
+// Our Github Actions will replace this with a commit SHA at release time
+// Right now this script is the only runtime asset published by our plugin
+// As we build out more runtime complexity into this plugin, this versioning should move there 
+export const PLUGIN_VERSION = "development";
+
 export default class SumerianHost extends Mesh {
   // Inspector fields
   private static initialCognitoIdValue = 'Fill in';
@@ -166,8 +171,12 @@ export default class SumerianHost extends Mesh {
       // else the Polly SDK's first call to Cognito.getID(...) will fail
       AWS.config.region = region;
 
-      const pollyClient = new AWS.Polly({credentials, region});
-      const pollyPresigner = new AWS.Polly.Presigner({service: pollyClient});
+      const customUserAgent = `AWSToolsForBabylonJSEditor-${PLUGIN_VERSION}`;
+
+      const pollyClient = new AWS.Polly({credentials, region, customUserAgent});
+      const pollyPresigner = new AWS.Polly.Presigner({
+        service: pollyClient,
+      });
 
       await HostObject.initTextToSpeech(pollyClient, pollyPresigner);
 


### PR DESCRIPTION
Similar to the other plugin, we are using an Action to rewrite the version number
This can be switched to release number for releases by changing the release Action

This is in a script that is copied by the plugin when a host is added. This means it will be trivial for the customer to delete if we want.

I'm not sure where the architecture of this plugin is going next, but we will have much better control if we move to a runtime library and custom inspector

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
