### PR TITLE
Add @amazon-sumerian-hosts/babylon to project dependencies

### DIFF
--- a/open-source-hosts-plugin/config/SceneRequirements.json
+++ b/open-source-hosts-plugin/config/SceneRequirements.json
@@ -1,6 +1,7 @@
 {
     "runtimeDependencies": {
         "@amazon-sumerian-hosts/babylon": "^2",
-        "aws-sdk": "^2.1096.0"
+        "aws-sdk": "^2.1096.0",
+        "util": "^0.12.4"
     }
 }

--- a/open-source-hosts-plugin/package-lock.json
+++ b/open-source-hosts-plugin/package-lock.json
@@ -11,7 +11,7 @@
             "license": "Apache 2.0",
             "dependencies": {
                 "@amazon-sumerian-hosts/babylon": "^2",
-                "@babylonjs/core": "4.2.0-rc.7",
+                "@babylonjs/core": "4.2.1",
                 "@blueprintjs/core": "^3.54.0",
                 "@types/node": "^17.0.21",
                 "aws-sdk": "^2.1096.0",
@@ -43,6 +43,7 @@
         "../../../aws-samples/amazon-sumerian-hosts/packages/amazon-sumerian-hosts-babylon": {
             "name": "@amazon-sumerian-hosts/babylon",
             "version": "2.0.0",
+            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "@amazon-sumerian-hosts/core": "^2.0.0",
@@ -54,8 +55,22 @@
             }
         },
         "node_modules/@amazon-sumerian-hosts/babylon": {
-            "resolved": "../../../aws-samples/amazon-sumerian-hosts/packages/amazon-sumerian-hosts-babylon",
-            "link": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@amazon-sumerian-hosts/babylon/-/babylon-2.0.0.tgz",
+            "integrity": "sha512-kqdNE3pUuAKY533Jz37QO+Y2JQzg20NAetZtS4EChkJjfM0Dgpr3gCbRSm8j1uZizvqe6ygvlxbqunpcLYfUrw==",
+            "dependencies": {
+                "@amazon-sumerian-hosts/core": "^2.0.0",
+                "aws-sdk": "^2.1094.0"
+            },
+            "peerDependencies": {
+                "@babylonjs/core": "^4.2.1",
+                "@babylonjs/loaders": "^4.2.1"
+            }
+        },
+        "node_modules/@amazon-sumerian-hosts/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@amazon-sumerian-hosts/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-O/jfwaMW+M6OUH1Xl4V8+G61xfixSqYSvSKiTaI/GMZ0j3vYVTzclFKOx3gtNf0860K5gK01+ov4K6J8+PzB0A=="
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.1.2",
@@ -522,11 +537,47 @@
             }
         },
         "node_modules/@babylonjs/core": {
-            "version": "4.2.0-rc.7",
-            "license": "Apache-2.0",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.1.tgz",
+            "integrity": "sha512-Z2ZVNRKPB1UvmMeqQtxCJKrQtQ/hb5FcAZi66YEEE0MKBQlLmf6oZEM9vS1RljPK7NZoV/dZSdwjJgiQlGsuhA==",
             "dependencies": {
                 "tslib": ">=1.10.0"
             },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@babylonjs/loaders": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.2.tgz",
+            "integrity": "sha512-Qk8r4xp4eOznbX3AsNYv8HgwS+tzGu6TwSpDX4il3g0B+k1N5k6KE5ghrnwDytoxUDVjGZ/VKk2cQqiHsg/NLg==",
+            "peer": true,
+            "dependencies": {
+                "@babylonjs/core": "4.2.2",
+                "babylonjs-gltf2interface": "4.2.2",
+                "tslib": ">=1.10.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@babylonjs/loaders/node_modules/@babylonjs/core": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.2.tgz",
+            "integrity": "sha512-gAgetSyoxFZ/xzMVVnGPKaP941NHA59Ho8GGKFW98OTEp8yZcnzJjNOD2zfF1eKmlvR/6WwSmcrKWTJtPF1pyA==",
+            "peer": true,
+            "dependencies": {
+                "tslib": ">=1.10.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@babylonjs/loaders/node_modules/babylonjs-gltf2interface": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.2.tgz",
+            "integrity": "sha512-LCQgW1lM+EpKK4yWMiPEgi6ONwJ7W4JrSu3t9JixNRgvnic72OnN2f0bt91rE30EJr1ZaokvkXD/aEiBp/Juyg==",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -8718,11 +8769,18 @@
     },
     "dependencies": {
         "@amazon-sumerian-hosts/babylon": {
-            "version": "file:../../../aws-samples/amazon-sumerian-hosts/packages/amazon-sumerian-hosts-babylon",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@amazon-sumerian-hosts/babylon/-/babylon-2.0.0.tgz",
+            "integrity": "sha512-kqdNE3pUuAKY533Jz37QO+Y2JQzg20NAetZtS4EChkJjfM0Dgpr3gCbRSm8j1uZizvqe6ygvlxbqunpcLYfUrw==",
             "requires": {
                 "@amazon-sumerian-hosts/core": "^2.0.0",
                 "aws-sdk": "^2.1094.0"
             }
+        },
+        "@amazon-sumerian-hosts/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@amazon-sumerian-hosts/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-O/jfwaMW+M6OUH1Xl4V8+G61xfixSqYSvSKiTaI/GMZ0j3vYVTzclFKOx3gtNf0860K5gK01+ov4K6J8+PzB0A=="
         },
         "@ampproject/remapping": {
             "version": "2.1.2",
@@ -9037,9 +9095,39 @@
             }
         },
         "@babylonjs/core": {
-            "version": "4.2.0-rc.7",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.1.tgz",
+            "integrity": "sha512-Z2ZVNRKPB1UvmMeqQtxCJKrQtQ/hb5FcAZi66YEEE0MKBQlLmf6oZEM9vS1RljPK7NZoV/dZSdwjJgiQlGsuhA==",
             "requires": {
                 "tslib": ">=1.10.0"
+            }
+        },
+        "@babylonjs/loaders": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@babylonjs/loaders/-/loaders-4.2.2.tgz",
+            "integrity": "sha512-Qk8r4xp4eOznbX3AsNYv8HgwS+tzGu6TwSpDX4il3g0B+k1N5k6KE5ghrnwDytoxUDVjGZ/VKk2cQqiHsg/NLg==",
+            "peer": true,
+            "requires": {
+                "@babylonjs/core": "4.2.2",
+                "babylonjs-gltf2interface": "4.2.2",
+                "tslib": ">=1.10.0"
+            },
+            "dependencies": {
+                "@babylonjs/core": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/@babylonjs/core/-/core-4.2.2.tgz",
+                    "integrity": "sha512-gAgetSyoxFZ/xzMVVnGPKaP941NHA59Ho8GGKFW98OTEp8yZcnzJjNOD2zfF1eKmlvR/6WwSmcrKWTJtPF1pyA==",
+                    "peer": true,
+                    "requires": {
+                        "tslib": ">=1.10.0"
+                    }
+                },
+                "babylonjs-gltf2interface": {
+                    "version": "4.2.2",
+                    "resolved": "https://registry.npmjs.org/babylonjs-gltf2interface/-/babylonjs-gltf2interface-4.2.2.tgz",
+                    "integrity": "sha512-LCQgW1lM+EpKK4yWMiPEgi6ONwJ7W4JrSu3t9JixNRgvnic72OnN2f0bt91rE30EJr1ZaokvkXD/aEiBp/Juyg==",
+                    "peer": true
+                }
             }
         },
         "@bcoe/v8-coverage": {

--- a/open-source-hosts-plugin/package.json
+++ b/open-source-hosts-plugin/package.json
@@ -45,7 +45,7 @@
     },
     "dependencies": {
         "@amazon-sumerian-hosts/babylon": "^2",
-        "@babylonjs/core": "4.2.0-rc.7",
+        "@babylonjs/core": "4.2.1",
         "@blueprintjs/core": "^3.54.0",
         "@types/node": "^17.0.21",
         "aws-sdk": "^2.1096.0",

--- a/open-source-hosts-plugin/scripts/sumerianhost.ts
+++ b/open-source-hosts-plugin/scripts/sumerianhost.ts
@@ -27,8 +27,8 @@ type SumerianHostVoiceConfiguration = {
 
 // Our Github Actions will replace this with a commit SHA at release time
 // Right now this script is the only runtime asset published by our plugin
-// As we build out more runtime complexity into this plugin, this versioning should move there 
-export const PLUGIN_VERSION = "development";
+// As we build out more runtime complexity into this plugin, this versioning should move there
+export const PLUGIN_VERSION = 'development';
 
 export default class SumerianHost extends Mesh {
   // Inspector fields

--- a/open-source-hosts-plugin/tools/retrieveHostAssets.js
+++ b/open-source-hosts-plugin/tools/retrieveHostAssets.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {spawnSync} = require('child_process');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const {existsSync, copySync, rmSync} = require('fs-extra');
+const {existsSync, copySync, rmSync, ensureDirSync} = require('fs-extra');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require('path');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -27,6 +27,8 @@ if (existsSync(assetsDir)) {
   process.exit(0);
 }
 
+// Clone repo with no history, no file content, and of only the topmost directory
+// This is essentially the 'smallest' clone we can do 
 console.log('Now downloading asset files -- this can take up to ten minutes');
 spawnSync(
   'git',
@@ -44,15 +46,20 @@ spawnSync(
 const hostDir = path.join(__dirname, '../amazon-sumerian-hosts');
 process.chdir(hostDir);
 
-spawnSync('git', ['sparse-checkout', 'set', 'd1', 'examples/assets'], {
+// Check out files matching this pattern -- in this case we're filtering by directory
+spawnSync('git', ['sparse-checkout', 'set', 'd1', 'packages/demos-babylon/src/character-assets'], {
   stdio: ['ignore', 'inherit', 'inherit'],
 });
 
 process.chdir('../');
 
+// We want our asset files to be nested under /gLTF
+const gLTFDir = path.join(assetsDir, 'gLTF');
+ensureDirSync(gLTFDir);
+
 copySync(
-  path.join(process.cwd(), 'amazon-sumerian-hosts/examples/assets'),
-  assetsDir
+  path.join(process.cwd(), 'amazon-sumerian-hosts/packages/demos-babylon/src/character-assets'),
+  gLTFDir
 );
 
 rmSync(hostDir, {recursive: true, force: true});


### PR DESCRIPTION
## Description
This change adds `@amazon-sumerian-hosts/babylon` to `SceneRequirements.json`, where an `npm install` of that dependency will be run on projects that have Sumerian hosts added to them.

Additionally, since the switch from `mainline` to `mainline2.0` in the Sumerian Hosts repo, the location from where we were pulling/installing assets needed to change.

Other minor fixes:
- Formatting of `sumerianhost.ts`
- Because Webpack 5.0 no longer automatically includes `util` as a polyfill when bundling a project, Webpack complains after the `aws-sdk` is installed that it can't find this library. It's not strictly necessary - in that the project will still compile and work without this dependency explicitly added - but there's a warning that will show up whenever the project is built that advises this change.


## Testing
I tested in the `4.1.1` version of the BabylonJS editor:
1.  I deleted the `assets/` directory and ran `npm i` to ensure the asset retrieval script still worked (mac OSX)
2. I ran `npm build`
3. I created a brand new workspace and went through the new workspace workflow in the BabylonJS Editor
4. I added a host to the scene 
5. I ran it in the editor, then compiled the project and ran it in the browser
6. I saved the scene and reloaded it
7. I again ran it in the editor, and then in the browser


---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.