### PR TITLE
change to deploy the whole project into Amplify 

### DIFF
--- a/aws-amplify-publisher-plugin/src/amplifyPublishDialog.tsx
+++ b/aws-amplify-publisher-plugin/src/amplifyPublishDialog.tsx
@@ -6,13 +6,11 @@ import React from 'react';
 import {Dialog} from '@blueprintjs/core';
 import fs from 'fs-extra';
 // eslint-disable-next-line import/no-unresolved
-import {Editor} from 'babylonjs-editor';
+import {Editor, SceneExporter} from 'babylonjs-editor';
 
 import {AmplifyClient} from '@aws-sdk/client-amplify';
 
 import {Status, PLUGIN_VERSION} from './constants';
-
-
 
 import {
   getAmplifyPublishingPreferences,
@@ -117,7 +115,9 @@ export class AmplifyPublishDialog extends React.Component<
       error: '',
     };
 
-    this.client = new AmplifyClient({customUserAgent: `AWSToolsForBabylonJS-${PLUGIN_VERSION}`});
+    this.client = new AmplifyClient({
+      customUserAgent: `AWSToolsForBabylonJS-${PLUGIN_VERSION}`,
+    });
   }
 
   /**
@@ -194,7 +194,9 @@ export class AmplifyPublishDialog extends React.Component<
     this.setState({status: Status.Progress});
 
     try {
-      artifactsPath = await zipArtifacts('tmpDir');
+      await SceneExporter.ExportFinalScene(this.props.editor);
+
+      artifactsPath = await zipArtifacts();
 
       // create an Amplify deployment
       const {jobId, zipUploadUrl} = await createAmplifyDeployment(

--- a/aws-amplify-publisher-plugin/src/constants.tsx
+++ b/aws-amplify-publisher-plugin/src/constants.tsx
@@ -13,4 +13,4 @@ export enum Status {
 }
 
 // Our Github Actions will replace this with a commit SHA at release time
-export const PLUGIN_VERSION = "development";
+export const PLUGIN_VERSION = 'development';

--- a/aws-amplify-publisher-plugin/src/toolbar.tsx
+++ b/aws-amplify-publisher-plugin/src/toolbar.tsx
@@ -75,6 +75,7 @@ export class AmplifyPublisherToolbar extends React.Component<
             text="AWS Amplify Hosting"
             onClick={this._handlePublishClick}
             shouldDismissPopover={false}
+            key="amplify-hosting-menu"
           />
         </Menu>
         <AmplifyPublishDialog

--- a/aws-amplify-publisher-plugin/src/toolbar.tsx
+++ b/aws-amplify-publisher-plugin/src/toolbar.tsx
@@ -75,7 +75,6 @@ export class AmplifyPublisherToolbar extends React.Component<
             text="AWS Amplify Hosting"
             onClick={this._handlePublishClick}
             shouldDismissPopover={false}
-            key="amplify-hosting-menu"
           />
         </Menu>
         <AmplifyPublishDialog

--- a/aws-amplify-publisher-plugin/src/utils.tsx
+++ b/aws-amplify-publisher-plugin/src/utils.tsx
@@ -3,7 +3,6 @@
 
 import fs from 'fs-extra';
 import archiver from 'archiver-promise';
-import path from 'path';
 // eslint-disable-next-line import/no-unresolved
 import {WorkSpace} from 'babylonjs-editor';
 /**
@@ -50,52 +49,18 @@ async function zipFile(
 
 /**
  * Compress the files needed to be host on the server.
- * @param folderPrefix the prefix of the folder's name.
  * @returns A Promise object that resolves the zip file path.
- * @throws An error if it fails to get WorkSpace DirPath or it does not exist.
  */
-export async function zipArtifacts(folderPrefix: string): Promise<string> {
-  let tmpDir: string | undefined;
+export async function zipArtifacts(): Promise<string> {
   const workSpaceDirPath = WorkSpace.DirPath;
-  try {
-    if (workSpaceDirPath !== null && fs.existsSync(workSpaceDirPath)) {
-      const now = new Date();
-      tmpDir = fs.mkdtempSync(
-        path.join(workSpaceDirPath, `${folderPrefix}${now.getTime()}`)
-      );
-
-      // get the scenes folder from the Editor project directory
-      const tmpDirScenes = path.join(tmpDir, 'scenes');
-      const scenesFolder = path.join(workSpaceDirPath, 'scenes');
-      fs.copySync(scenesFolder, tmpDirScenes);
-
-      // get the dist folder from the Editor project directory
-      const tmpDirDist = path.join(tmpDir, 'dist');
-      const distFolder = path.join(workSpaceDirPath, 'dist');
-      fs.copySync(distFolder, tmpDirDist);
-
-      // get the index.html from the Editor project directory
-      const tempIndexHTML = path.join(tmpDir, 'index.html');
-      const indexHTML = path.join(workSpaceDirPath, 'index.html');
-      fs.copyFileSync(indexHTML, tempIndexHTML);
-    } else {
-      throw new Error(
-        `Cannot get WorkSpace directory ${workSpaceDirPath}, or it does not exist.`
-      );
-    }
-    const zipFilePath = `${tmpDir}.zip`;
-    return await zipFile(tmpDir, zipFilePath);
-  } finally {
-    try {
-      if (tmpDir) {
-        fs.rmdirSync(tmpDir, {recursive: true});
-      }
-    } catch (error) {
-      console.error(
-        `An error has occurred while removing the temp folder at ${tmpDir}. Please remove it manually. ${error}`
-      );
-    }
+  console.log(workSpaceDirPath);
+  if (workSpaceDirPath == null || !fs.existsSync(workSpaceDirPath)) {
+    throw new Error(
+      `Cannot get WorkSpace directory ${workSpaceDirPath}, or it does not exist.`
+    );
   }
+  const zipFilePath = `${workSpaceDirPath}.zip`;
+  return zipFile(workSpaceDirPath, zipFilePath);
 }
 
 /**

--- a/aws-amplify-publisher-plugin/src/utils.tsx
+++ b/aws-amplify-publisher-plugin/src/utils.tsx
@@ -53,7 +53,6 @@ async function zipFile(
  */
 export async function zipArtifacts(): Promise<string> {
   const workSpaceDirPath = WorkSpace.DirPath;
-  console.log(workSpaceDirPath);
   if (workSpaceDirPath == null || !fs.existsSync(workSpaceDirPath)) {
     throw new Error(
       `Cannot get WorkSpace directory ${workSpaceDirPath}, or it does not exist.`


### PR DESCRIPTION
### Description of changes:
After adding the script to the Host, the published scene failed to find the animation file saved in the `assets` folder which was not uploaded into the Amplify Side. Therefore, we change to upload the whole project file currently to bypass this issue. The long-term solution is to fix this issue in the Editor side since the `scene/_asset` folder missed some assets saved in the `assets` folder. Issue on the Editor side: https://github.com/BabylonJS/Editor/issues/373

### Testing
- Added the host into the scene.
- Published the scene to the Amplify.
- Opened the generated url and the animation worked well.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
