### PR TITLE
add instruction to disable SSAO

### DIFF
--- a/open-source-hosts-plugin/README.md
+++ b/open-source-hosts-plugin/README.md
@@ -30,6 +30,8 @@ To debug the plugin, press ctrl+alt+I (or cmd+option+I on a mac) to bring up the
 
 ### Add a host to the scene
 
+**Note:** Please disable the SSAO (Scene -> Inspector -> Rendering -> Disable SSAO 2) to fix the lighting issue until this problem gets fixed by BabylonJS Editor.
+
 Locate `Open Source Hosts Tools` in the editor toolbars. When you expand "Add Hosts", you will see a submenu of possible host types, each with their own unique model. Select one to spawn it at the origin of your scene. This will also copy the necessary assets and install the requisite dependencies into your project workspace.
 
 The script `sumerianhost.ts` will be added into your project source; the file will load and configure animations at runtime, such as blinking, lip sync, gestures, etc. The host will track the main camera by default; the configuration of this behavior can be found in this script.

--- a/open-source-hosts-plugin/README.md
+++ b/open-source-hosts-plugin/README.md
@@ -30,7 +30,7 @@ To debug the plugin, press ctrl+alt+I (or cmd+option+I on a mac) to bring up the
 
 ### Add a host to the scene
 
-**Note:** Please disable the SSAO (Scene -> Inspector -> Rendering -> Disable SSAO 2) to fix the lighting issue until this problem gets fixed by BabylonJS Editor.
+**Note:** There is a known issue that causes undesirable shadowing artifacts when you use the Host characters. This is due to an issue in Babylon.js Editor version v4.2.0 with Babylon.js v4.2.1. Until this bug is fixed, you can disable the Screen Space Ambient Occlusion(SSAO) post-processing effect to avoid the issue. Please use the following steps: 1. Click **Scene** in the Graph List. 2. In the Inspector window, select **Rendering** tab. 3. Toggle the **SSAO 2** off.
 
 Locate `Open Source Hosts Tools` in the editor toolbars. When you expand "Add Hosts", you will see a submenu of possible host types, each with their own unique model. Select one to spawn it at the origin of your scene. This will also copy the necessary assets and install the requisite dependencies into your project workspace.
 

--- a/open-source-hosts-plugin/README.md
+++ b/open-source-hosts-plugin/README.md
@@ -30,7 +30,7 @@ To debug the plugin, press ctrl+alt+I (or cmd+option+I on a mac) to bring up the
 
 ### Add a host to the scene
 
-**Note:** There is a known issue that causes undesirable shadowing artifacts when you use the Host characters. This is due to an issue in Babylon.js Editor version v4.2.0 with Babylon.js v4.2.1. Until this bug is fixed, you can disable the Screen Space Ambient Occlusion(SSAO) post-processing effect to avoid the issue. Please use the following steps: 1. Click **Scene** in the Graph List. 2. In the Inspector window, select **Rendering** tab. 3. Toggle the **SSAO 2** off.
+**Note:** There is a known issue that causes undesirable shadowing artifacts when you use the Host characters. This is due to an issue in Babylon.js Editor v4.2.0 with Babylon.js v4.2.1. Until this bug is fixed, you can disable the Screen Space Ambient Occlusion(SSAO) post-processing effect to avoid the issue. Please use the following steps: 1. Click **Scene** in the Graph List. 2. In the Inspector window, select **Rendering** tab. 3. Toggle the **SSAO 2** off.
 
 Locate `Open Source Hosts Tools` in the editor toolbars. When you expand "Add Hosts", you will see a submenu of possible host types, each with their own unique model. Select one to spawn it at the origin of your scene. This will also copy the necessary assets and install the requisite dependencies into your project workspace.
 


### PR DESCRIPTION
*Description of changes:*
Added an instruction in the open host plugin README for customers to disable the SSAO before the lighting issue gets fixed by BabylonJS Editor.

By this [conversation](https://forum.babylonjs.com/t/importing-gltf-and-glb-to-editor-are-different/30045/6?u=zzmarmot), this issue was caused by the outdated BabylonJS version. The maintainer of the Editor will work on an update later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
