### PR TITLE
Fix: configure CodeQL to ignore docs & dependencies

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - '**/packages/**/dist'
+  - '**/docs_template'

--- a/.github/workflows/amplify-plugin-pull-request.yml
+++ b/.github/workflows/amplify-plugin-pull-request.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
+        with: 
+          config-file: ./.github/codeql/codeql-config.yml
+          debug: true
       - uses: actions/setup-node@v1
         with:
           node-version: "16.x"

--- a/.github/workflows/amplify-plugin-pull-request.yml
+++ b/.github/workflows/amplify-plugin-pull-request.yml
@@ -19,7 +19,6 @@ jobs:
         uses: github/codeql-action/init@v1
         with: 
           config-file: ./.github/codeql/codeql-config.yml
-          debug: true
       - uses: actions/setup-node@v1
         with:
           node-version: "16.x"

--- a/.github/workflows/host-plugin-pull-request.yml
+++ b/.github/workflows/host-plugin-pull-request.yml
@@ -16,7 +16,6 @@ jobs:
         uses: github/codeql-action/init@v1
         with: 
           config-file: ./.github/codeql/codeql-config.yml
-          debug: true
       # Write the commit hash into the script file, so we get the git hash in the built artifacts
       # Believe it or not, the following perl statement works on ubuntu/windows/macos
       - name: "Set version number"

--- a/.github/workflows/host-plugin-pull-request.yml
+++ b/.github/workflows/host-plugin-pull-request.yml
@@ -14,29 +14,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
-
-      # We depend on the Hosts package, but it is not published yet
-      # So for now let's build it here too and link it like we do on local workstation
-      # From here down to the 'END HOSTS SETUP' token below, we can delete once that package is published
-      - uses: actions/checkout@v3
-        with:
-          repository: "aws-samples/amazon-sumerian-hosts"
-          ref: "mainline2.0"
-          path: "hosts"
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "16.x"
-          registry-url: "https://registry.npmjs.org"
-      - run: npm install
-        working-directory: "./hosts"
-      - run: npm run build
-        working-directory: "./hosts"
-      # The babylon hosts package isn't published yet, so for now we install it
-      # from a local checkout so our references work during the build
-      - run: npm install ../hosts/packages/amazon-sumerian-hosts-babylon
-        working-directory: "./open-source-hosts-plugin"
-      # END HOSTS SETUP
-
+        with: 
+          config-file: ./.github/codeql/codeql-config.yml
+          debug: true
       # Write the commit hash into the script file, so we get the git hash in the built artifacts
       # Believe it or not, the following perl statement works on ubuntu/windows/macos
       - name: "Set version number"


### PR DESCRIPTION
*Description of changes:*
This change configures CodeQL so that it is limited only to our source code and not analyzing dependencies. 

Additionally, since the Host package has been published to npm, we can remove the part in the workflow that pulls and builds it locally.

Note: you can add `debug: true` to the CodeQL step, like so:
```
      - name: Initialize CodeQL
        uses: github/codeql-action/init@v1
        with: 
          config-file: ./.github/codeql/codeql-config.yml
          debug: true
```

This will generate an archive called `debug-artifacts-ubuntu-latest` that can be found in the workflow. Unzipped, there is a log available at `javascript/log/dataset-import-...` that appears to show what files are being looked over. I looked at this to ensure that our project source files were being scanned.

--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
