### PR TITLE
Fix: replace manual asset configuration with SceneImportTools

### DIFF
--- a/open-source-hosts-plugin/package-lock.json
+++ b/open-source-hosts-plugin/package-lock.json
@@ -24,7 +24,7 @@
                 "@types/jest": "^27.4.1",
                 "@typescript-eslint/eslint-plugin": "^5.16.0",
                 "@typescript-eslint/parser": "^5.16.0",
-                "babylonjs-editor": "^4.1.0",
+                "babylonjs-editor": "^4.1.1",
                 "eslint": "^8.11.0",
                 "eslint-config-airbnb": "^19.0.4",
                 "eslint-config-prettier": "^8.5.0",
@@ -2332,9 +2332,10 @@
             }
         },
         "node_modules/babylonjs-editor": {
-            "version": "4.1.0",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/babylonjs-editor/-/babylonjs-editor-4.2.0.tgz",
+            "integrity": "sha512-RKiCe7x4PrRcPZ0HzEYWWk/Pnw5das9Ks7o3jIuJ0DQ2mYNjDYnfU0V29Py8wIZEDVTlFX+pbtYeQrKg5YvDTw==",
             "dev": true,
-            "license": "(Apache-2.0)",
             "dependencies": {
                 "@blueprintjs/core": "3.28.1",
                 "@blueprintjs/select": "3.13.2",
@@ -10398,7 +10399,9 @@
             "version": "4.2.2"
         },
         "babylonjs-editor": {
-            "version": "4.1.0",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/babylonjs-editor/-/babylonjs-editor-4.2.0.tgz",
+            "integrity": "sha512-RKiCe7x4PrRcPZ0HzEYWWk/Pnw5das9Ks7o3jIuJ0DQ2mYNjDYnfU0V29Py8wIZEDVTlFX+pbtYeQrKg5YvDTw==",
             "dev": true,
             "requires": {
                 "@blueprintjs/core": "3.28.1",

--- a/open-source-hosts-plugin/package.json
+++ b/open-source-hosts-plugin/package.json
@@ -31,7 +31,7 @@
         "@types/jest": "^27.4.1",
         "@typescript-eslint/eslint-plugin": "^5.16.0",
         "@typescript-eslint/parser": "^5.16.0",
-        "babylonjs-editor": "^4.1.0",
+        "babylonjs-editor": "^4.1.1",
         "eslint": "^8.11.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",

--- a/open-source-hosts-plugin/src/hostAdder.ts
+++ b/open-source-hosts-plugin/src/hostAdder.ts
@@ -6,16 +6,8 @@
 /* eslint-disable class-methods-use-this */
 
 import {HostObject} from '@amazon-sumerian-hosts/babylon';
-import {
-  AssetContainer,
-  Material,
-  Scene,
-  SceneLoader,
-  Skeleton,
-  Texture,
-} from 'babylonjs';
-import {Tools} from 'babylonjs-editor';
-import {existsSync} from 'fs';
+import {AssetContainer, Scene, SceneLoader} from 'babylonjs';
+import {Editor, SceneImporterTools} from 'babylonjs-editor';
 import path from 'path';
 import {
   RELATIVE_ASSETS_DIR,
@@ -75,7 +67,10 @@ class SumerianHostAdder {
    * @param {Babylon.Scene} scene
    * @returns {Babylon.AssetContainer}
    */
-  public async addToScene(scene: Scene) {
+  public async addToScene(scene: Scene, editor: Editor) {
+    const absModelPath = this.characterConfig.modelUrl;
+    const relModelPath = path.relative(this.workSpaceAssetsDir, absModelPath);
+
     // this renders the Host in the current scene
     const characterAsset = await SceneLoader.LoadAssetContainerAsync(
       this.characterConfig.modelUrl,
@@ -86,110 +81,19 @@ class SumerianHostAdder {
     // rename mesh to something human-readable instead of the default '__root__'
     characterAsset.meshes[0].name = this.characterId;
 
-    this.fixTextures(
-      this.workSpaceAssetsDir,
-      characterAsset.textures as Texture[]
-    );
-    this.fixMaterials(this.workSpaceAssetsDir, characterAsset.materials);
-    this.fixBones(characterAsset.skeletons[0], scene);
-
     characterAsset.addAllToScene();
 
+    // the editor expects the mesh to be configured a certain way, so that
+    // saving and reloading the scene will work
+    await SceneImporterTools.Configure(scene, {
+      isGltf: true,
+      relativePath: relModelPath,
+      absolutePath: absModelPath,
+      editor,
+      result: characterAsset,
+    });
+
     return characterAsset;
-  }
-
-  /**
-   * The editor expects the properties of textures that point to where they're
-   * stored to be relative paths that are based off the workspace's asset directory,
-   * rather than the absolute ones that the default GLTF asset loader sets.
-   *
-   * @param workspaceAssetsDir The absolute path to the workspace's assets directory
-   * @param textures The array of textures to be fixed
-   */
-  private fixTextures(workspaceAssetsDir: string, textures: Texture[]) {
-    textures.forEach((tex: Texture) => {
-      if (tex.url && tex.url.startsWith('data:')) {
-        const textureDir = tex.url.split(':')[1];
-
-        // check to ensure that this is actually a directory, and not embedded data --
-        // we expect it to be the absolute path to the texture directory
-        if (!existsSync(textureDir)) {
-          return;
-        }
-
-        const relativeTextureDir = path.dirname(
-          path.relative(workspaceAssetsDir, textureDir)
-        );
-
-        const textureFileName = path.basename(tex.url);
-        const relativeTexturePath = path.join(
-          relativeTextureDir,
-          textureFileName
-        );
-
-        // the editor will call path.exists on the name property
-        tex.name = relativeTexturePath;
-        // the texture will then be loaded from the url
-        tex.url = relativeTexturePath;
-      }
-    });
-  }
-
-  /**
-   * The editor expects certain pieces of metadata on materials to be set in order for it to
-   * export and then re-import them correctly.
-   * @param workspaceAssetsDir The absolute path to the workspace's assets directory
-   * @param materials The array of materials to be fixed
-   */
-  private fixMaterials(workspaceAssetsDir: string, materials: Material[]) {
-    // the model file points to textures stored in a subdirectory called 'textures'
-    // this will be the absolute path to that directory
-    const textureDirectory = path.join(
-      path.dirname(this.characterConfig.modelUrl),
-      'textures'
-    );
-
-    const relTextureDirectory = path.relative(
-      workspaceAssetsDir,
-      textureDirectory
-    );
-
-    materials.forEach((material: Material) => {
-      material.metadata ??= {};
-      // if this metadata property is not set, the editor
-      // will not export the material
-      material.metadata.editorPath = path.join(
-        relTextureDirectory,
-        `${material.name}.material`
-      );
-    });
-  }
-
-  /**
-   * The editor expects certain properties about skeletons and bones to be true before
-   * they will be exported/re-imported correctly
-   * @param skeleton The host skeleton to fix
-   * @param scene The scene the skeleton will be imported into
-   */
-  private fixBones(skeleton: Skeleton | null, scene: Scene) {
-    if (!skeleton) return;
-
-    // The editor will use the skeleton id as an index into an array,
-    // so it needs to be a number - let's find a unique one
-    let id = 0;
-    while (scene.getSkeletonById(id as any)) {
-      id += 1;
-    }
-
-    skeleton.id = id as any;
-    skeleton.bones?.forEach((bone) => {
-      // bone IDs also need to be unique, but can be strings
-      bone.id = Tools.RandomId();
-
-      // the editor expects these properties to be set
-      bone.metadata ??= {};
-      bone.metadata.originalId = bone.id;
-    });
   }
 
   /**

--- a/open-source-hosts-plugin/src/hostMenu.tsx
+++ b/open-source-hosts-plugin/src/hostMenu.tsx
@@ -92,7 +92,7 @@ export default class SumerianAddHostMenu extends React.Component<ISumerianAddHos
           25,
           'Adding Sumerian Host to scene'
         );
-        const characterAsset = await hostAdder.addToScene(currentScene);
+        const characterAsset = await hostAdder.addToScene(currentScene, editor);
 
         editor.updateTaskFeedback(
           addHostProgress,


### PR DESCRIPTION
## Description
[This change](https://github.com/BabylonJS/Editor/commit/0d99327bd683cc45d8230400806950c34df0814c) released in 4.1.1 of the Editor allows us to use the same import logic the editor uses when a gltf file is drag-dropped into the scene from the asset manager. 

This allows us to remove all of the (frankly hacky and hard to maintain) code that was written to subtly manipulate paths and metadata so that hosts would save and reload properly.

## Testing done
1. Create a new (blank) project
2. Add a host from `Open Source Hosts Tools`
3. Press play, confirm that the host animates properly and looks at the camera
4. Save, and then `File -> Reload Project`
5. Confirm that the host is not missing textures
6. Press play again and confirm that the host still animates properly and looks at the camera
7. Additionally, press `Run...` and then `Open in browser` to ensure that textures/animations load properly when the project is run from the browser
--
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
